### PR TITLE
Slide und Webseite-URL angepasst

### DIFF
--- a/_data/review-2020.yaml
+++ b/_data/review-2020.yaml
@@ -63,7 +63,7 @@ linuxuser:
         <li>- Was brauche ich um mit Docker zu starten?</li>
         <li>- Was sind die Vorteile von Containern?</li>
         <li>- Wie sehen moderne Infrastrukturen aus?</li>
-        <li>- <a href="https://static.muench.dev/presentation/docker/index.html#1">Vortrag Slideshow</a> zum nachlesen.</li>
+        <li>- <a href="https://muench.dev/slides/docker/#1">Vortrag Slideshow</a> zum nachlesen.</li>
         </ul>
 
         <strong>Virtualisierung am Beispiel von Proxmox VE und VirtualBox</strong><br />

--- a/linux_worms.md
+++ b/linux_worms.md
@@ -23,7 +23,7 @@ Beim allerletzten Treffen am 24.10.2013 kamen plötzlich ein paar neue Leute. Ho
 
 #### Am 3.11 2015 gründet sich der Wormser Linux User Stammtisch ####
 
-am 06.07.2016 beginnen die Aufzeichnung der neu gegründeten WOLUST mit [Christian](https://blog.muench-worms.de/) ,Mike und [Stefan](https://stefan-höhn.de/)
+am 06.07.2016 beginnen die Aufzeichnung der neu gegründeten WOLUST mit [Christian](https://muench.dev/) ,Mike und [Stefan](https://stefan-höhn.de/)
 
 Wir haben in Worms mehrere Gastwirtschaften ausprobiert und sind jetzt im Timescafe am Ludwigsplatz, wegen des guten Essens und kostenlosem WLAN.
 

--- a/talk-repo.md
+++ b/talk-repo.md
@@ -29,7 +29,7 @@ sitemap: true
 1. Klaus: [SCEP-EST-ACME]({{ site.baseurl }}/SCEP-EST-ACME)
 2. Achim: [Ceph und Proxmox]({{ site.baseurl }}/ceph-und-proxmox)
 3. Stefan: [Linux installieren gestern und heute](https://www.untergang.de/html-folien030302020-vhs/img0.html) Externer Link
-4. Christian: [Einführung in die Container Technologie](https://static.muench.dev/presentation/docker/index.html#1) Externer Link
+4. Christian: [Einführung in die Container Technologie](https://muench.dev/slides/docker/#1) Externer Link
 5. Achim: [Virtualisierung am Beispiel von Proxmox VE und VirtualBox](https://achwo.de/?download=Virtualisierung.pdf) Extern pdf
 6. Christian: [Division By Zero PHPUnit](https://github.com/Wolust/test-division-by-zero) Extern Github
 7. Christian: [Linux Dateisystem](https://speakerdeck.com/cmuench/linux-dateisystem)


### PR DESCRIPTION
Die Domäne wurde von muench-worms.de auf muench.dev geändert.